### PR TITLE
Fix conda-ci by using mambaforge directly

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -42,9 +42,8 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        mamba-version: "*"
-        channels: conda-forge,defaults
-        channel-priority: true
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
 
     - name: Dependencies
       shell: bash -l {0}


### PR DESCRIPTION
Currently the CI is failing with a weird conflict error. This is due to the fact that we are install mamba on the top of miniconda3 . We solve the problem by directly using mambaforge .

Similar to:
* https://github.com/robotology/robotology-superbuild/pull/840
* https://github.com/robotology/robometry/pull/141