### PR TITLE
Fix CI on macOS and Windows

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -77,7 +77,7 @@ jobs:
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c conda-forge -c robostack-experimental -c robostack-humble ycm-cmake-modules eigen ace ros-${{ matrix.ros_distro }}-ros-base ros-${{ matrix.ros_distro }}-test-msgs
+        mamba install -c conda-forge -c robostack-staging ycm-cmake-modules eigen ace ros-${{ matrix.ros_distro }}-ros-base ros-${{ matrix.ros_distro }}-test-msgs
 
 
     - name: Download YARP [Linux&macOS]

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -155,19 +155,19 @@ jobs:
         cd build
         cmake --build . --config ${{ matrix.build_type }}
 
-    - name: Test [Linux&macOS]
-      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
-      shell: bash -l {0}
-      run: |
-        cd build
-        ctest --output-on-failure -C ${{ matrix.build_type }}
-
     - name: Install [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
         cd build
         cmake --install . --config ${{ matrix.build_type }}
+
+    - name: Test [Linux&macOS]
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+      shell: bash -l {0}
+      run: |
+        cd build
+        ctest --output-on-failure -C ${{ matrix.build_type }}
 
     - name: Build [Windows]
       if: contains(matrix.os, 'windows')

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -142,11 +142,11 @@ jobs:
         mkdir -p build
         cd build
         cmake -G"Visual Studio 16 2019" -DBUILD_TESTING:BOOL=ON ^
-              -DYARP_ROS2_USE_SYSTEM_map2d_nws_ros2_msgs:BOOL=OFF ^
-              -DPython3_EXECUTABLE:PATH=%CONDA_PREFIX%\python.exe ^
-              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ^
-              -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}\Library .. ^
-              -DYARP_COMPILE_TESTS:BOOL=ON
+                                        -DYARP_ROS2_USE_SYSTEM_map2d_nws_ros2_msgs:BOOL=OFF ^
+                                        -DPython3_EXECUTABLE:PATH=%CONDA_PREFIX%\python.exe ^
+                                        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ^
+                                        -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}\Library .. ^
+                                        -DYARP_COMPILE_TESTS:BOOL=ON
 
     - name: Build [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -131,7 +131,7 @@ jobs:
                       -DPython3_EXECUTABLE:PATH=$CONDA_PREFIX/bin/python3 \
                       -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
                       -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-                      -DCMAKE_INSTALL_PREFIX=./install .. \
+                      -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} .. \
                       -DYARP_COMPILE_TESTS:BOOL=ON
 
     - name: Configure [Windows]
@@ -141,7 +141,12 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -G"Visual Studio 16 2019" -DBUILD_TESTING:BOOL=ON -DYARP_ROS2_USE_SYSTEM_map2d_nws_ros2_msgs:BOOL=OFF -DPython3_EXECUTABLE:PATH=%CONDA_PREFIX%\python.exe -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=.\install .. -DYARP_COMPILE_TESTS:BOOL=ON
+        cmake -G"Visual Studio 16 2019" -DBUILD_TESTING:BOOL=ON ^
+              -DYARP_ROS2_USE_SYSTEM_map2d_nws_ros2_msgs:BOOL=OFF ^
+              -DPython3_EXECUTABLE:PATH=%CONDA_PREFIX%\python.exe ^
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ^
+              -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}\Library .. ^
+              -DYARP_COMPILE_TESTS:BOOL=ON
 
     - name: Build [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -176,6 +176,13 @@ jobs:
         cd build
         cmake --build . --config ${{ matrix.build_type }}
 
+    - name: Install [Windows]
+      if: contains(matrix.os, 'windows')
+      shell: cmd /C CALL {0}
+      run: |
+        cd build
+        cmake --install . --config ${{ matrix.build_type }}
+
     - name: Test [Windows]
       if: contains(matrix.os, 'windows')
       shell: cmd /C CALL {0}
@@ -183,9 +190,3 @@ jobs:
         cd build
         ctest --output-on-failure -C ${{ matrix.build_type }}
 
-    - name: Install [Windows]
-      if: contains(matrix.os, 'windows')
-      shell: cmd /C CALL {0}
-      run: |
-        cd build
-        cmake --install . --config ${{ matrix.build_type }}

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -141,12 +141,7 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -G"Visual Studio 16 2019" -DBUILD_TESTING:BOOL=ON \
-                                        -DYARP_ROS2_USE_SYSTEM_map2d_nws_ros2_msgs:BOOL=OFF \
-                                        -DPython3_EXECUTABLE:PATH=%CONDA_PREFIX%\python.exe \
-                                        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-                                        -DCMAKE_INSTALL_PREFIX=.\install .. \
-                                        -DYARP_COMPILE_TESTS:BOOL=ON
+        cmake -G"Visual Studio 16 2019" -DBUILD_TESTING:BOOL=ON -DYARP_ROS2_USE_SYSTEM_map2d_nws_ros2_msgs:BOOL=OFF -DPython3_EXECUTABLE:PATH=%CONDA_PREFIX%\python.exe -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=.\install .. -DYARP_COMPILE_TESTS:BOOL=ON
 
     - name: Build [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
This PR fixes the following aspects:
* Fix the configuration line on Windows to use `^` instead of `/` as line separators
* Switches to use the latest ros2 robostack packages from the robostack-staging channel

